### PR TITLE
Add lazy_constant.

### DIFF
--- a/pythonflow/operations.py
+++ b/pythonflow/operations.py
@@ -135,3 +135,27 @@ class Logger:
     @functools.wraps(logging.Logger.critical)
     def critical(self, message, *args, **kwargs):  # pylint: disable=missing-docstring
         return func_op(self.logger.critical, message, *args, **kwargs)
+
+
+class lazy_constant(Operation):  # pylint: disable=invalid-name
+    """
+    Operation that returns the output of `target` lazily.
+
+    Parameters
+    ----------
+    target : callable
+        Function to evaluate when the operation is evaluated.
+    kwargs : dict
+        Keyword arguments passed to the constructor of `Operation`.
+    """
+    def __init__(self, target, **kwargs):
+        super(lazy_constant, self).__init__(**kwargs)
+        self.target = target
+        if not callable(self.target):
+            raise ValueError("`target` must be callable")
+        self.value = None
+
+    def _evaluate(self):  # pylint: disable=W0221
+        if self.value is None:
+            self.value = self.target()
+        return self.value

--- a/tests/test_pythonflow.py
+++ b/tests/test_pythonflow.py
@@ -277,3 +277,22 @@ def test_lazy_import():
     missing = pf.lazy_import('some_missing_module')
     with pytest.raises(ImportError):
         _ = missing.missing_attribute
+
+
+def test_lazy_constant():
+    import time
+
+    def target():
+        time.sleep(1)
+        return 12345
+
+    with pf.Graph() as graph:
+        value = pf.lazy_constant(target)
+
+    start = time.time()
+    assert graph(value) == 12345
+    assert time.time() - start > 1
+
+    start = time.time()
+    assert graph(value) == 12345
+    assert time.time() - start < 0.01

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
     "name": "pythonflow",
     "description": "Dataflow programming for python",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "author": "Till Hoffmann",
     "author_email": "till@spotify.com",
     "license": "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This PR adds a `lazy_constant` operation that can be used to delay the evaluation of constants in the graph until they are first used.