### PR TITLE
Added length parameter in pf conditional

### DIFF
--- a/pythonflow/operations.py
+++ b/pythonflow/operations.py
@@ -41,8 +41,8 @@ class conditional(Operation):  # pylint: disable=C0103,W0223
     Note that the conditional operation will only execute one branch of the computation graph
     depending on `predicate`.
     """
-    def __init__(self, predicate, x, y=None, *, name=None, dependencies=None):  # pylint: disable=W0235
-        super(conditional, self).__init__(predicate, x, y, name=name, dependencies=dependencies)
+    def __init__(self, predicate, x, y=None, *, length=None, name=None, dependencies=None):  # pylint: disable=W0235
+        super(conditional, self).__init__(predicate, x, y, length=length, name=name, dependencies=dependencies)
 
     def evaluate(self, context, callback=None):
         # Evaluate all dependencies first

--- a/pythonflow/operations.py
+++ b/pythonflow/operations.py
@@ -42,7 +42,8 @@ class conditional(Operation):  # pylint: disable=C0103,W0223
     depending on `predicate`.
     """
     def __init__(self, predicate, x, y=None, *, length=None, name=None, dependencies=None):  # pylint: disable=W0235
-        super(conditional, self).__init__(predicate, x, y, length=length, name=name, dependencies=dependencies)
+        super(conditional, self).__init__(predicate, x, y,
+                                          length=length, name=name, dependencies=dependencies)
 
     def evaluate(self, context, callback=None):
         # Evaluate all dependencies first

--- a/tests/test_pythonflow.py
+++ b/tests/test_pythonflow.py
@@ -196,6 +196,21 @@ def test_conditional():
         graph(z, condition=False)
 
 
+def test_conditional_with_length():
+    def f(a):
+        return a, a
+
+    with pf.Graph() as graph:
+        x = pf.constant(4)
+        y = pf.placeholder(name='y')
+        condition = pf.placeholder(name='condition')
+
+        z1, z2 = pf.conditional(condition, pf.func_op(f, x), pf.func_op(f, y), length=2)
+
+    assert graph([z1, z2], condition=True) == (4, 4)
+    assert graph([z1, z2], condition=False, y=5) == (5, 5)
+
+
 @pytest.mark.parametrize('message', [None, "x should be smaller than %d but got %d"])
 def test_assert_with_dependencies(message):
     with pf.Graph() as graph:

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
     "name": "pythonflow",
     "description": "Dataflow programming for python",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "author": "Till Hoffmann",
     "author_email": "till@spotify.com",
     "license": "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
It is now possible to return more than 1 element with pf.conditional by specifying its length