### PR TITLE
Add kwargs to placeholder.

### DIFF
--- a/pythonflow/operations.py
+++ b/pythonflow/operations.py
@@ -27,8 +27,8 @@ class placeholder(Operation):  # pylint: disable=C0103,R0903
     """
     Placeholder that needs to be given in the context to be evaluated.
     """
-    def __init__(self, name=None):
-        super(placeholder, self).__init__(name=name)
+    def __init__(self, name=None, **kwargs):
+        super(placeholder, self).__init__(name=name, **kwargs)
 
     def _evaluate(self):  # pylint: disable=W0221
         raise ValueError("missing value for placeholder '%s'" % self.name)

--- a/tests/test_pythonflow.py
+++ b/tests/test_pythonflow.py
@@ -527,3 +527,11 @@ def test_stack_trace():
         raise RuntimeError("did not raise ZeroDivisionError")
     except ZeroDivisionError as ex:
         assert isinstance(ex.__cause__, pf.EvaluationError)
+
+
+def test_placeholder_with_kwargs():
+    with pf.Graph() as graph:
+        a = pf.placeholder(length=2)
+        b, c = a
+
+    assert graph([b, c], {a: [1, 2]}) == (1, 2)


### PR DESCRIPTION
Placeholders cannot be unpacked at the moment because the `length` argument is not passed to the super class constructor.