### PR TITLE
Make Pythonflow thread-compatible.

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
     "name": "pythonflow",
     "description": "Dataflow programming for python",
-    "version": "0.2.3",
+    "version": "0.3.0",
     "author": "Till Hoffmann",
     "author_email": "till@spotify.com",
     "license": "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Previously it was impossible to use `pythonflow` in a multithreaded application: with this patch it is possible to use distinct `pythonflow` graphs, one per-thread.