### PR TITLE
Fixed documentation typo in opmethod function in core.py

### DIFF
--- a/pythonflow/core.py
+++ b/pythonflow/core.py
@@ -531,11 +531,11 @@ def opmethod(target=None, **kwargs):
     """
     Decorator for creating operations from functions.
     """
-    # This is called when the decorator is used with arguments
+    # This is called when the decorator is used without arguments
     if target is None:
         return functools.partial(opmethod, **kwargs)
 
-    # This is called when the decorator is used without arguments
+    # This is called when the decorator is used with arguments
     @functools.wraps(target)
     def _wrapper(*args, **kwargs_inner):
         return func_op(target, *args, **kwargs_inner, **kwargs)


### PR DESCRIPTION
```def opmethod(target=None, **kwargs):
    """
    Decorator for creating operations from functions.
    """
    # This is called when the decorator is used with arguments
    if target is None:
        return functools.partial(opmethod, **kwargs)

    # This is called when the decorator is used without arguments
    @functools.wraps(target)
    def _wrapper(*args, **kwargs_inner):
        return func_op(target, *args, **kwargs_inner, **kwargs)
    return _wrapper
```

the words 'with' and 'without' is mistakenly interchanged in documentation in above funciton