### PR TITLE
update: adjust to satisfy deprication

### DIFF
--- a/pythonflow/core.py
+++ b/pythonflow/core.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import builtins
-import collections
+import collections.abc as collections
 import contextlib
 import functools
 import importlib


### PR DESCRIPTION
Python 3.9 will be breaking collections
according to pytest's warnings summary